### PR TITLE
Support subscription change requests with array payloads

### DIFF
--- a/lib/Core/SubscriptionChange/SubscriptionChangeRequestParser.php
+++ b/lib/Core/SubscriptionChange/SubscriptionChangeRequestParser.php
@@ -15,16 +15,24 @@ class SubscriptionChangeRequestParser {
 	}
 
 	/**
-	 * @param string $urlsSubscribed
-	 * @param string $urlsUnsubscribed
+	 * @param string|array $urlsSubscribed
+	 * @param string|array $urlsUnsubscribed
 	 *
 	 * @return SubscriptionChange[]
 	 */
-	public function createSubscriptionChangeList(string $urlsSubscribed, string $urlsUnsubscribed): array {
-		$urlsToSubscribe = $this->subscriptionChangeReader->fromString($urlsSubscribed, true);
-		$urlsToDelete = $this->subscriptionChangeReader->fromString($urlsUnsubscribed, false);
+	public function createSubscriptionChangeList($urlsSubscribed, $urlsUnsubscribed): array {
+		if (is_array($urlsSubscribed)) {
+			$urlsToSubscribe = $this->subscriptionChangeReader->fromArray($urlsSubscribed, true);
+		} else {
+			$urlsToSubscribe = $this->subscriptionChangeReader->fromString($urlsSubscribed, true);
+		}
+		if (is_array($urlsUnsubscribed)) {
+			$urlsToDelete = $this->subscriptionChangeReader->fromArray($urlsUnsubscribed, false);
+		} else {
+			$urlsToDelete = $this->subscriptionChangeReader->fromString($urlsUnsubscribed, false);
+		}
 
-		/** @var \OCA\GPodderSync\Core\SubscriptionChange\SubscriptionChange[] $subscriptionChanges */
+		/** @var SubscriptionChange[] $subscriptionChanges */
 		return array_merge($urlsToSubscribe, $urlsToDelete);
 	}
 }

--- a/lib/Core/SubscriptionChange/SubscriptionChangeSaver.php
+++ b/lib/Core/SubscriptionChange/SubscriptionChangeSaver.php
@@ -37,7 +37,12 @@ class SubscriptionChangeSaver {
 		$this->subscriptionChangeRequestParser = $subscriptionChangeRequestParser;
 	}
 
-	public function saveSubscriptionChanges(string $urlsSubscribed, string $urlsUnsubscribed, string $userId): void {
+	/**
+	 * @param string|array $urlsSubscribed
+	 * @param string|array $urlsUnsubscribed
+	 * @param string $userId
+	 */
+	public function saveSubscriptionChanges($urlsSubscribed, $urlsUnsubscribed, string $userId): void {
 		$subscriptionChanges = $this->subscriptionChangeRequestParser->createSubscriptionChangeList($urlsSubscribed, $urlsUnsubscribed);
 		foreach ($subscriptionChanges as $urlChangedSubscriptionStatus) {
 			$subscriptionChangeEntity = new SubscriptionChangeEntity();

--- a/lib/Core/SubscriptionChange/SubscriptionChangesReader.php
+++ b/lib/Core/SubscriptionChange/SubscriptionChangesReader.php
@@ -7,10 +7,10 @@ class SubscriptionChangesReader {
 
 	/**
 	 * @param string $raw
-	 *
+	 * @param bool $subscribed
 	 * @return array|SubscriptionChange[]
 	 */
-	public function fromString(string $raw, bool $subscribed):? array {
+	public function fromString(string $raw, bool $subscribed): array {
 		$urls = str_replace(["[", "]", " "], "", $raw);
 		$urlList = explode(",", $urls);
 
@@ -25,4 +25,16 @@ class SubscriptionChangesReader {
 		return $subscriptionChanges;
 	}
 
+	/**
+	 * @param array $raw
+	 * @param bool $subscribed
+	 * @return array|SubscriptionChange[]
+	 */
+	public function fromArray(array $raw, bool $subscribed): array {
+		$subscriptionChanges = [];
+		foreach ($raw as $url) {
+			$subscriptionChanges[] = $this->fromString($url, $subscribed)[0];
+		}
+		return $subscriptionChanges;
+	}
 }

--- a/tests/Unit/Core/SubscriptionChange/SubscriptionChangeReaderTest.php
+++ b/tests/Unit/Core/SubscriptionChange/SubscriptionChangeReaderTest.php
@@ -7,17 +7,27 @@ use OCA\GPodderSync\Core\SubscriptionChange\SubscriptionChangesReader;
 use Test\TestCase;
 
 class SubscriptionChangeReaderTest extends TestCase {
+	private SubscriptionChangesReader $reader;
+
+	protected function setUp(): void {
+		$this->reader = new SubscriptionChangesReader();
+	}
+
 	public function testCreateFromString(): void {
-		$reader = new SubscriptionChangesReader();
-		$subscriptionChange = $reader->fromString('[https://feeds.megaphone.fm/HSW8286374095]', true);
+		$subscriptionChange = $this->reader->fromString('[https://feeds.megaphone.fm/HSW8286374095]', true);
 		$this->assertCount(1, $subscriptionChange);
 		$this->assertSame("https://feeds.megaphone.fm/HSW8286374095", $subscriptionChange[0]->getUrl());
 	}
 
 	public function testCreateFromEmptyString(): void {
-		$reader = new SubscriptionChangesReader();
-		$subscriptionChange = $reader->fromString('[]', true);
+		$subscriptionChange = $this->reader->fromString('[]', true);
 		$this->assertCount(0, $subscriptionChange);
 	}
 
+	public function testCreateFromArray(): void {
+		$subscriptionChange = $this->reader->fromArray(['https://example.com/feed.rss', 'https://example.org/podcast.php'], true);
+		$this->assertCount(2, $subscriptionChange);
+		$this->assertSame("https://example.com/feed.rss", $subscriptionChange[0]->getUrl());
+		$this->assertSame("https://example.org/podcast.php", $subscriptionChange[1]->getUrl());
+	}
 }


### PR DESCRIPTION
In the [gpodder.net API docs for subscriptions](https://gpoddernet.readthedocs.io/en/latest/api/reference/subscriptions.html), the JSON payload for "subscription changes" contains arrays of feed URLs. The current version of this app supports comma separated strings of URLs.

This PR adds support for arrays while maintaining the existing behaviour.