### PR TITLE
Solve timezone problems in episode change synchronization

### DIFF
--- a/lib/Controller/EpisodeActionController.php
+++ b/lib/Controller/EpisodeActionController.php
@@ -112,6 +112,6 @@ class EpisodeActionController extends Controller {
 	{
 		return \DateTime::createFromFormat('D F d H:i:s T Y', $timestamp)
 			->setTimezone(new DateTimeZone('UTC'))
-			->format("Y-m-d H:i:s");
+			->format("Y-m-d\TH:i:s");
 	}
 }

--- a/lib/Controller/EpisodeActionController.php
+++ b/lib/Controller/EpisodeActionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace OCA\GPodderSync\Controller;
 
 use DateTime;
+use DateTimeZone;
 use GuzzleHttp\Psr7\Response;
 use OCA\GPodderSync\Core\EpisodeAction\EpisodeActionReader;
 use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionEntity;
@@ -110,6 +111,7 @@ class EpisodeActionController extends Controller {
 	private function convertTimestampToDbDateTimeString(string $timestamp)
 	{
 		return \DateTime::createFromFormat('D F d H:i:s T Y', $timestamp)
-			->format("Y-m-d\TH:i:s");
+			->setTimezone(new DateTimeZone('UTC'))
+			->format("Y-m-d H:i:s");
 	}
 }


### PR DESCRIPTION
Hi, I think I got it.

I just changed the timezone of the timestamp that gets saved into `oc_gpodder_episode_action` to UTC.

The old timezone gets extracted by `createFromFormat('D F d H:i:s T Y', $timestamp)` so the conversion should work in any timezone.

I also changed the output format for the timestamp because I didn't understood why there was a 'T' in it: `'2021-07-24T18:34:26'`. They now look like the other timestamps: `'2021-07-24 16:56:07'`.
Is that okay or was the T in there for a reason?

And please check that my code does not destroy anything... This is my first commit/pull request ever ^^
