### PR TITLE
Correct faulty timestamp check in episode and subscription list requests

### DIFF
--- a/lib/Controller/EpisodeActionController.php
+++ b/lib/Controller/EpisodeActionController.php
@@ -98,7 +98,7 @@ class EpisodeActionController extends Controller {
 	 * @return DateTime
 	 */
 	private function createDateTimeFromTimestamp(?int $since): DateTime {
-		return ($since)
+		return ($since !== null)
 			? (new \DateTime)->setTimestamp($since)
 			: (new \DateTime('-1 week'));
 	}

--- a/lib/Controller/SubscriptionChangeController.php
+++ b/lib/Controller/SubscriptionChangeController.php
@@ -73,7 +73,7 @@ class SubscriptionChangeController extends Controller {
 	 * @return DateTime
 	 */
 	private function createDateTimeFromTimestamp(?int $since): DateTime {
-		return ($since)
+		return ($since !== null)
 			? (new \DateTime)->setTimestamp($since)
 			: (new \DateTime('-1 week'));
 	}


### PR DESCRIPTION
createDateTimeFromTimestamp interpreted 0 as timestamp as faulty while 0 is a valid timestamp.
The fix checks if timestamp is null (not defined/initialized), so that 0 is treated as a correct timestamp.