### PR TITLE
Stop creating unnecessary log file in Nextcloud root folder

### DIFF
--- a/lib/Core/EpisodeAction/EpisodeActionReader.php
+++ b/lib/Core/EpisodeAction/EpisodeActionReader.php
@@ -5,14 +5,11 @@ namespace OCA\GPodderSync\Core\EpisodeAction;
 
 class EpisodeActionReader {
 	public function fromString(string $episodeActionString): EpisodeAction {
-		file_put_contents('actionreader.log', var_export($episodeActionString, true), FILE_APPEND);
 		preg_match(
 			'/\[EpisodeAction{(podcast=\')(?<podcast>.*?)(\', episode=\')(?<episode>.*?)(\', action=)(?<action>.*?)(, timestamp=)(?<timestamp>.*?)(, started=)(?<started>.*?)(, position=)(?<position>.*?)(, total=)(?<total>.*?)}]*/',
 			$episodeActionString,
 			$matches
 		);
-
-		file_put_contents('actionreader.log', var_export($matches, true), FILE_APPEND);
 
 		return new EpisodeAction(
 			$matches["podcast"],


### PR DESCRIPTION
Hi, I hope it's not too late for this change to go into v1.0.10 ^^

EpisodeActionReader created (or appended to) file actionreader.log in Nextcloud base folder (with index.php & occ). This concluded in a Nextcloud warning about "additional files in Nextcloud folder" in the self-check feature.

```
Technical information
=====================
The following list covers which files have failed the integrity check. Please read
the previous linked documentation to learn more about the errors and how to fix
them.

Results
=======
- core
	- EXTRA_FILE
		- actionreader.log

Raw output
==========
Array
(
    [core] => Array
        (
            [EXTRA_FILE] => Array
                (
                    [actionreader.log] => Array
                        (
                            [expected] => 
                            [current] => 070b97d3237d176d08d7df22d11f560ac2f4a38d126dbc6730ccd0b32a276c393d9521ed69b58e3ab3579910f12d56e30c4ae9d75c000beb9e1ffd0e02332fa8
                        )

                )

        )

)
```