### PR TITLE
Use EpisodeAction.guid as identifier if available

### DIFF
--- a/lib/Controller/EpisodeActionController.php
+++ b/lib/Controller/EpisodeActionController.php
@@ -42,7 +42,7 @@ class EpisodeActionController extends Controller {
 	 * @return Response
 	 */
 	public function create($data) {
-		return $this->episodeActionSaver->saveEpisodeAction($data, $this->userId);
+		return $this->episodeActionSaver->saveEpisodeActions($data, $this->userId);
 	}
 
 	/**

--- a/lib/Core/EpisodeAction/EpisodeAction.php
+++ b/lib/Core/EpisodeAction/EpisodeAction.php
@@ -11,6 +11,7 @@ class EpisodeAction {
 	private int $started;
 	private int $position;
 	private int $total;
+	private ?string $guid;
 
 	public function __construct(
 		string $podcast,
@@ -19,7 +20,8 @@ class EpisodeAction {
 		string $timestamp,
 		int $started,
 		int $position,
-		int $total
+		int $total,
+		?string $guid
 	) {
 		$this->podcast = $podcast;
 		$this->episode = $episode;
@@ -28,6 +30,7 @@ class EpisodeAction {
 		$this->started = $started;
 		$this->position = $position;
 		$this->total = $total;
+		$this->guid = $guid;
 	}
 
 	/**
@@ -75,8 +78,14 @@ class EpisodeAction {
 	/**
 	 * @return int
 	 */
-	public function getTotal(): int {
+	public function getTotal(): int
+	{
 		return $this->total;
+	}
+
+	public function getGuid() : ?string
+	{
+		return $this->guid;
 	}
 
 

--- a/lib/Core/EpisodeAction/EpisodeActionReader.php
+++ b/lib/Core/EpisodeAction/EpisodeActionReader.php
@@ -3,41 +3,53 @@ declare(strict_types=1);
 
 namespace OCA\GPodderSync\Core\EpisodeAction;
 
-class EpisodeActionReader {
+class EpisodeActionReader
+{
 
-    const EPISODEACTION_IDENTIFIER = 'EpisodeAction{';
+	const EPISODEACTION_IDENTIFIER = 'EpisodeAction{';
 
 	/**
 	 * @param string $episodeActionsString
 	 * @return EpisodeAction[]
 	 */
-	public function fromString(string $episodeActionsString): array {
-		
+	public function fromString(string $episodeActionsString): array
+	{
+
+
+		$patterns = [
+			'/EpisodeAction{(podcast=\')(?<podcast>.*?)(\', episode=\')(?<episode>.*?)(\', guid=\')(?<guid>.*?)(\', action=)(?<action>.*?)(, timestamp=)(?<timestamp>.*?)(, started=)(?<started>.*?)(, position=)(?<position>.*?)(, total=)(?<total>.*?)}]*/',
+			'/EpisodeAction{(podcast=\')(?<podcast>.*?)(\', episode=\')(?<episode>.*?)(\', action=)(?<action>.*?)(, timestamp=)(?<timestamp>.*?)(, started=)(?<started>.*?)(, position=)(?<position>.*?)(, total=)(?<total>.*?)}]*/',
+		];
+
 		$episodeActions = [];
 
-        $episodeActionStrings = explode(self::EPISODEACTION_IDENTIFIER, $episodeActionsString);
-        array_shift($episodeActionStrings);
-        
-        foreach($episodeActionStrings as $episodeActionString) {
+		$episodeActionStrings = explode(self::EPISODEACTION_IDENTIFIER, $episodeActionsString);
+		array_shift($episodeActionStrings);
 
-            preg_match(
-                '/EpisodeAction{(podcast=\')(?<podcast>.*?)(\', episode=\')(?<episode>.*?)(\', action=)(?<action>.*?)(, timestamp=)(?<timestamp>.*?)(, started=)(?<started>.*?)(, position=)(?<position>.*?)(, total=)(?<total>.*?)}]*/',
-                self::EPISODEACTION_IDENTIFIER . $episodeActionString,
-                $matches
-            );
+		foreach ($episodeActionStrings as $episodeActionString) {
+			foreach ($patterns as $pattern) {
+				preg_match(
+					$pattern,
+					self::EPISODEACTION_IDENTIFIER . $episodeActionString,
+					$matches
+				);
 
-            $episodeActions[] = new EpisodeAction(
-                $matches["podcast"],
-                $matches["episode"],
-                $matches["action"],
-                $matches["timestamp"],
-                (int)$matches["started"],
-                (int)$matches["position"],
-                (int)$matches["total"],
-            );
-        }
+				if ($matches["action"] !== null) {
+					$episodeActions[] = new EpisodeAction(
+						$matches["podcast"],
+						$matches["episode"],
+						$matches["action"],
+						$matches["timestamp"],
+						(int)$matches["started"],
+						(int)$matches["position"],
+						(int)$matches["total"],
+						$matches["guid"] ?? null,
+					);
+					break;
+				}
+			}
 
+		}
 		return $episodeActions;
 	}
-
 }

--- a/lib/Core/EpisodeAction/EpisodeActionSaver.php
+++ b/lib/Core/EpisodeAction/EpisodeActionSaver.php
@@ -84,12 +84,12 @@ class EpisodeActionSaver
 		);
 
 		if ($episodeActionEntityToUpdate === null && $episodeActionEntity->getGuid() !== null) {
-			$episodeActionEntityToUpdate = $this->getOldEpisodeActionByEpisodeUrl(
-				$episodeActionEntity->getEpisode(), $userId
-			);
+			$episodeActionEntityToUpdate = $this->getOldEpisodeActionByEpisodeUrl($episodeActionEntity->getEpisode(), $userId);
 		}
 
 		$episodeActionEntity->setId($episodeActionEntityToUpdate->getId());
+
+		$this->assertGuidDoesNotGetNulledWithOldData($episodeActionEntityToUpdate, $episodeActionEntity);
 
 		return $this->episodeActionWriter->update($episodeActionEntity);
 	}
@@ -106,6 +106,14 @@ class EpisodeActionSaver
 			$episodeUrl,
 			$userId
 		);
+	}
+
+	private function assertGuidDoesNotGetNulledWithOldData(EpisodeActionEntity $episodeActionEntityToUpdate, EpisodeActionEntity $episodeActionEntity): void
+	{
+		$existingGuid = $episodeActionEntityToUpdate->getGuid();
+		if ($existingGuid !== null && $episodeActionEntity->getGuid() == null) {
+			$episodeActionEntity->setGuid($existingGuid);
+		}
 	}
 
 	/**

--- a/lib/Core/EpisodeAction/EpisodeActionSaver.php
+++ b/lib/Core/EpisodeAction/EpisodeActionSaver.php
@@ -84,15 +84,28 @@ class EpisodeActionSaver
 		);
 
 		if ($episodeActionEntityToUpdate === null && $episodeActionEntity->getGuid() !== null) {
-			$episodeActionEntityToUpdate = $this->episodeActionRepository->findByEpisodeIdentifier(
-				$episodeActionEntity->getEpisode(),
-				$userId
+			$episodeActionEntityToUpdate = $this->getOldEpisodeActionByEpisodeUrl(
+				$episodeActionEntity->getEpisode(), $userId
 			);
 		}
-		$idEpisodeActionEntityToUpdate = $episodeActionEntityToUpdate->getId();
-		$episodeActionEntity->setId($idEpisodeActionEntityToUpdate);
+
+		$episodeActionEntity->setId($episodeActionEntityToUpdate->getId());
 
 		return $this->episodeActionWriter->update($episodeActionEntity);
+	}
+
+	/**
+	 * @param string $episodeUrl
+	 * @param string $userId
+	 *
+	 * @return EpisodeActionEntity|null
+	 */
+	private function getOldEpisodeActionByEpisodeUrl(string $episodeUrl, string $userId): ?EpisodeActionEntity
+	{
+		return $this->episodeActionRepository->findByEpisodeIdentifier(
+			$episodeUrl,
+			$userId
+		);
 	}
 
 	/**

--- a/lib/Core/EpisodeAction/EpisodeActionSaver.php
+++ b/lib/Core/EpisodeAction/EpisodeActionSaver.php
@@ -33,7 +33,7 @@ class EpisodeActionSaver
 	 *
 	 * @return EpisodeActionEntity[]
 	 */
-	public function saveEpisodeAction($data, string $userId): array
+	public function saveEpisodeAction(string $data, string $userId): array
 	{
 		$episodeActionEntities = [];
 
@@ -77,7 +77,7 @@ class EpisodeActionSaver
 		string $userId
 	): EpisodeActionEntity
 	{
-		$idEpisodeActionEntityToUpdate = $this->episodeActionRepository->findByEpisode(
+		$idEpisodeActionEntityToUpdate = $this->episodeActionRepository->findByEpisodeIdentifier(
 			$episodeActionEntity->getEpisode(),
 			$userId
 		)->getId();

--- a/lib/Core/EpisodeAction/EpisodeActionSaver.php
+++ b/lib/Core/EpisodeAction/EpisodeActionSaver.php
@@ -55,11 +55,6 @@ class EpisodeActionSaver
 		return $episodeActionEntities;
 	}
 
-	/**
-	 * @param string $timestamp
-	 *
-	 * @return string
-	 */
 	private function convertTimestampToDbDateTimeString(string $timestamp): string
 	{
 		return \DateTime::createFromFormat('D F d H:i:s T Y', $timestamp)
@@ -67,11 +62,6 @@ class EpisodeActionSaver
 			->format("Y-m-d\TH:i:s");
 	}
 
-	/**
-	 * @param EpisodeActionEntity $episodeActionEntity
-	 *
-	 * @return EpisodeActionEntity
-	 */
 	private function updateEpisodeAction(
 		EpisodeActionEntity $episodeActionEntity,
 		string $userId
@@ -94,12 +84,6 @@ class EpisodeActionSaver
 		return $this->episodeActionWriter->update($episodeActionEntity);
 	}
 
-	/**
-	 * @param string $episodeUrl
-	 * @param string $userId
-	 *
-	 * @return EpisodeActionEntity|null
-	 */
 	private function getOldEpisodeActionByEpisodeUrl(string $episodeUrl, string $userId): ?EpisodeActionEntity
 	{
 		return $this->episodeActionRepository->findByEpisodeIdentifier(
@@ -116,12 +100,6 @@ class EpisodeActionSaver
 		}
 	}
 
-	/**
-	 * @param EpisodeAction $episodeAction
-	 * @param string $userId
-	 *
-	 * @return EpisodeActionEntity
-	 */
 	private function hydrateEpisodeActionEntity(EpisodeAction $episodeAction, string $userId): EpisodeActionEntity
 	{
 		$episodeActionEntity = new EpisodeActionEntity();

--- a/lib/Core/EpisodeAction/EpisodeActionSaver.php
+++ b/lib/Core/EpisodeAction/EpisodeActionSaver.php
@@ -89,7 +89,7 @@ class EpisodeActionSaver
 
 		$episodeActionEntity->setId($episodeActionEntityToUpdate->getId());
 
-		$this->assertGuidDoesNotGetNulledWithOldData($episodeActionEntityToUpdate, $episodeActionEntity);
+		$this->ensureGuidDoesNotGetNulledWithOldData($episodeActionEntityToUpdate, $episodeActionEntity);
 
 		return $this->episodeActionWriter->update($episodeActionEntity);
 	}
@@ -108,7 +108,7 @@ class EpisodeActionSaver
 		);
 	}
 
-	private function assertGuidDoesNotGetNulledWithOldData(EpisodeActionEntity $episodeActionEntityToUpdate, EpisodeActionEntity $episodeActionEntity): void
+	private function ensureGuidDoesNotGetNulledWithOldData(EpisodeActionEntity $episodeActionEntityToUpdate, EpisodeActionEntity $episodeActionEntity): void
 	{
 		$existingGuid = $episodeActionEntityToUpdate->getGuid();
 		if ($existingGuid !== null && $episodeActionEntity->getGuid() == null) {

--- a/lib/Core/EpisodeAction/EpisodeActionSaver.php
+++ b/lib/Core/EpisodeAction/EpisodeActionSaver.php
@@ -33,7 +33,7 @@ class EpisodeActionSaver
 	 *
 	 * @return EpisodeActionEntity[]
 	 */
-	public function saveEpisodeAction(string $data, string $userId): array
+	public function saveEpisodeActions(string $data, string $userId): array
 	{
 		$episodeActionEntities = [];
 
@@ -77,10 +77,19 @@ class EpisodeActionSaver
 		string $userId
 	): EpisodeActionEntity
 	{
-		$idEpisodeActionEntityToUpdate = $this->episodeActionRepository->findByEpisodeIdentifier(
-			$episodeActionEntity->getEpisode(),
+		$identifier = $episodeActionEntity->getGuid() ?? $episodeActionEntity->getEpisode();
+		$episodeActionEntityToUpdate = $this->episodeActionRepository->findByEpisodeIdentifier(
+			$identifier,
 			$userId
-		)->getId();
+		);
+
+		if ($episodeActionEntityToUpdate === null && $episodeActionEntity->getGuid() !== null) {
+			$episodeActionEntityToUpdate = $this->episodeActionRepository->findByEpisodeIdentifier(
+				$episodeActionEntity->getEpisode(),
+				$userId
+			);
+		}
+		$idEpisodeActionEntityToUpdate = $episodeActionEntityToUpdate->getId();
 		$episodeActionEntity->setId($idEpisodeActionEntityToUpdate);
 
 		return $this->episodeActionWriter->update($episodeActionEntity);
@@ -97,6 +106,7 @@ class EpisodeActionSaver
 		$episodeActionEntity = new EpisodeActionEntity();
 		$episodeActionEntity->setPodcast($episodeAction->getPodcast());
 		$episodeActionEntity->setEpisode($episodeAction->getEpisode());
+		$episodeActionEntity->setGuid($episodeAction->getGuid());
 		$episodeActionEntity->setAction($episodeAction->getAction());
 		$episodeActionEntity->setPosition($episodeAction->getPosition());
 		$episodeActionEntity->setStarted($episodeAction->getStarted());

--- a/lib/Db/EpisodeAction/EpisodeActionEntity.php
+++ b/lib/Db/EpisodeAction/EpisodeActionEntity.php
@@ -15,6 +15,7 @@ class EpisodeActionEntity extends Entity implements JsonSerializable {
 	protected $started;
 	protected $total;
 	protected $timestamp;
+	protected $guid;
 	protected $userId;
 
 	public function __construct() {
@@ -26,6 +27,7 @@ class EpisodeActionEntity extends Entity implements JsonSerializable {
 			'id' => $this->id,
 			'podcast' => $this->podcast,
 			'episode' => $this->episode,
+			'guid' => $this->guid,
 			'action' => $this->action,
 			'position' => $this->position,
 			'started' => $this->started,

--- a/lib/Db/EpisodeAction/EpisodeActionMapper.php
+++ b/lib/Db/EpisodeAction/EpisodeActionMapper.php
@@ -32,7 +32,7 @@ class EpisodeActionMapper extends \OCP\AppFramework\Db\QBMapper
 		return $this->findEntities($qb);
 	}
 
-	public function findByEpisodeIdentifier(string $episodeIdentifier, string $userId) : EpisodeActionEntity
+	public function findByEpisodeIdentifier(string $episodeIdentifier, string $userId) : ?EpisodeActionEntity
 	{
 		$qb = $this->db->getQueryBuilder();
 
@@ -55,5 +55,7 @@ class EpisodeActionMapper extends \OCP\AppFramework\Db\QBMapper
 		} catch (DoesNotExistException $e) {
 		} catch (MultipleObjectsReturnedException $e) {
 		}
+
+		return null;
 	}
 }

--- a/lib/Db/EpisodeAction/EpisodeActionRepository.php
+++ b/lib/Db/EpisodeAction/EpisodeActionRepository.php
@@ -17,7 +17,8 @@ class EpisodeActionRepository {
 		return $this->episodeActionMapper->findAll($sinceTimestamp, $userId);
 	}
 
-	public function findByEpisode(string $episode,  string $userId): EpisodeActionEntity {
-		return $this->episodeActionMapper->findByEpisode($episode, $userId);
+	public function findByEpisodeIdentifier(string $identifier, string $userId): EpisodeActionEntity {
+		return $this->episodeActionMapper->findByEpisodeIdentifier($identifier, $userId);
 	}
+
 }

--- a/lib/Db/EpisodeAction/EpisodeActionRepository.php
+++ b/lib/Db/EpisodeAction/EpisodeActionRepository.php
@@ -17,7 +17,7 @@ class EpisodeActionRepository {
 		return $this->episodeActionMapper->findAll($sinceTimestamp, $userId);
 	}
 
-	public function findByEpisodeIdentifier(string $identifier, string $userId): EpisodeActionEntity {
+	public function findByEpisodeIdentifier(string $identifier, string $userId): ?EpisodeActionEntity {
 		return $this->episodeActionMapper->findByEpisodeIdentifier($identifier, $userId);
 	}
 

--- a/lib/Db/EpisodeAction/EpisodeActionWriter.php
+++ b/lib/Db/EpisodeAction/EpisodeActionWriter.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace OCA\GPodderSync\Db\EpisodeAction;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-
 class EpisodeActionWriter {
 
 	/**

--- a/lib/Migration/Version0004Date20210823115513.php
+++ b/lib/Migration/Version0004Date20210823115513.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace OCA\GPodderSync\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+
+class Version0004Date20210823115513 extends \OCP\Migration\SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('gpodder_episode_action');
+		$table->addColumn('guid', Types::STRING, [
+			'length' => 500,
+			'notnull' => false
+		]);
+
+		$table->addUniqueIndex(['guid', 'user_id'], 'gpodder_guid_user_id');
+
+		return $schema;
+	}
+}

--- a/tests/Helper/DatabaseTransaction.php
+++ b/tests/Helper/DatabaseTransaction.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace tests\Helper;
+
+use OC;
+use OCP\IDBConnection;
+
+trait DatabaseTransaction {
+
+	public function startTransaction() {
+		/* @var $db IDBConnection */
+		$db = OC::$server->get(IDBConnection::class);
+
+		$db->beginTransaction();
+	}
+
+	public function rollbackTransation() {
+		/* @var $db IDBConnection */
+		$db = OC::$server->get(IDBConnection::class);
+
+		$db->rollBack();
+	}
+
+}

--- a/tests/Integration/AppTest.php
+++ b/tests/Integration/AppTest.php
@@ -15,7 +15,7 @@ class AppTest extends TestCase {
 
     private $container;
 
-    public function setUp() : void {
+    public function setUp(): void {
         parent::setUp();
         $app = new App('gpoddersync');
         $this->container = $app->getContainer();

--- a/tests/Integration/EpisodeActionGuidMigrationTest.php
+++ b/tests/Integration/EpisodeActionGuidMigrationTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace tests\Integration;
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionEntity;
+use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionWriter;
+use OCP\AppFramework\App;
+use Test\TestCase;
+use tests\Helper\DatabaseTransaction;
+
+/**
+ * @group DB
+ */
+class EpisodeActionGuidMigrationTest extends TestCase
+{
+	use DatabaseTransaction;
+
+	private \OCP\AppFramework\IAppContainer $container;
+
+	public function setUp(): void {
+		parent::setUp();
+		$app = new App('gpoddersync');
+		$this->container = $app->getContainer();
+	}
+
+	/**
+	 * @before
+	 */
+	public function before()
+	{
+		$this->startTransaction();
+	}
+
+	public function testCreateSameEpisodeActionTriggersUniqueConstraintViolationException()
+	{
+		self::expectException(UniqueConstraintViolationException::class);
+
+		/** @var EpisodeActionWriter $episodeActionWriter */
+		$episodeActionWriter = $this->container->get('OCA\GPodderSync\Db\EpisodeAction\EpisodeActionWriter');
+
+		$episodeActionEntity = new EpisodeActionEntity();
+		$episodeActionEntity->setPodcast("https://podcast_01.url");
+		$episodeActionEntity->setEpisode("https://episode_01.url");
+		$episodeActionEntity->setAction("PLAY");
+		$episodeActionEntity->setPosition(5);
+		$episodeActionEntity->setStarted(0);
+		$episodeActionEntity->setTotal(123);
+		$episodeActionEntity->setTimestamp("Mon Aug 23 01:58:56 GMT+02:00 2021");
+		$episodeActionEntity->setUserId("user0@127.0.0.1");
+		$episodeActionWriter->save($episodeActionEntity);
+
+		$episodeActionWriter->save($episodeActionEntity);
+
+	}
+
+	/**
+	 * @after
+	 */
+	public function after()
+	{
+		$this->rollbackTransation();
+	}
+}

--- a/tests/Integration/EpisodeActionGuidMigrationTest.php
+++ b/tests/Integration/EpisodeActionGuidMigrationTest.php
@@ -5,6 +5,7 @@ namespace tests\Integration;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OCA\GPodderSync\Core\EpisodeAction\EpisodeActionReader;
+use OCA\GPodderSync\Core\EpisodeAction\EpisodeActionSaver;
 use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionEntity;
 use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionRepository;
 use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionWriter;
@@ -28,11 +29,17 @@ class EpisodeActionGuidMigrationTest extends TestCase
 	 */
 	private $episodeActionWriter;
 
+	/**
+	 * @var EpisodeActionRepository
+	 */
+	private $episodeActionRepository;
+
 	public function setUp(): void {
 		parent::setUp();
 		$app = new App('gpoddersync');
 		$this->container = $app->getContainer();
 		$this->episodeActionWriter = $this->container->get(EpisodeActionWriter::class);
+		$this->episodeActionRepository = $this->container->get(EpisodeActionRepository::class);
 	}
 
 	/**
@@ -63,6 +70,10 @@ class EpisodeActionGuidMigrationTest extends TestCase
 
 	}
 
+	/**
+	 *
+	 * @group findme
+	 */
 	public function testFindEpisodeActionByEpisodeUrlAndThenGuid()
 	{
 		$episodeActionEntity = new EpisodeActionEntity();
@@ -76,12 +87,9 @@ class EpisodeActionGuidMigrationTest extends TestCase
 		$episodeActionEntity->setUserId(self::USER_ID_0);
 		$savedEpisodeActionEntity = $this->episodeActionWriter->save($episodeActionEntity);
 
-		/** @var EpisodeActionRepository $episodeActionRepository */
-		$episodeActionRepository = $this->container->get(EpisodeActionRepository::class);
-
 		self::assertSame(
 			$savedEpisodeActionEntity->getId(),
-			$episodeActionRepository->findByEpisodeIdentifier($episodeActionEntity->getEpisode(), self::USER_ID_0)->getId()
+			$this->episodeActionRepository->findByEpisodeIdentifier($episodeActionEntity->getEpisode(), self::USER_ID_0)->getId()
 		);
 
 		//update same episode action again this time with guid
@@ -92,12 +100,12 @@ class EpisodeActionGuidMigrationTest extends TestCase
 
 		self::assertSame(
 			$savedEpisodeActionEntityWithGuid->getId(),
-			$episodeActionRepository->findByEpisodeIdentifier($episodeActionEntityWithGuid->getEpisode(), self::USER_ID_0)->getId()
+			$this->episodeActionRepository->findByEpisodeIdentifier($episodeActionEntityWithGuid->getEpisode(), self::USER_ID_0)->getId()
 		);
 
 		self::assertSame(
 			$savedEpisodeActionEntityWithGuid->getId(),
-			$episodeActionRepository->findByEpisodeIdentifier($episodeActionEntityWithGuid->getGuid(), self::USER_ID_0)->getId()
+			$this->episodeActionRepository->findByEpisodeIdentifier($episodeActionEntityWithGuid->getGuid(), self::USER_ID_0)->getId()
 		);
 
 	}

--- a/tests/Integration/EpisodeActionGuidMigrationTest.php
+++ b/tests/Integration/EpisodeActionGuidMigrationTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 namespace tests\Integration;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use OCA\GPodderSync\Core\EpisodeAction\EpisodeActionReader;
 use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionEntity;
+use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionRepository;
 use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionWriter;
 use OCP\AppFramework\App;
 use Test\TestCase;
@@ -17,12 +19,20 @@ class EpisodeActionGuidMigrationTest extends TestCase
 {
 	use DatabaseTransaction;
 
+	private const USER_ID_0 = "user0@127.0.0.1";
+
 	private \OCP\AppFramework\IAppContainer $container;
+
+	/**
+	 * @var EpisodeActionWriter
+	 */
+	private $episodeActionWriter;
 
 	public function setUp(): void {
 		parent::setUp();
 		$app = new App('gpoddersync');
 		$this->container = $app->getContainer();
+		$this->episodeActionWriter = $this->container->get(EpisodeActionWriter::class);
 	}
 
 	/**
@@ -37,9 +47,6 @@ class EpisodeActionGuidMigrationTest extends TestCase
 	{
 		self::expectException(UniqueConstraintViolationException::class);
 
-		/** @var EpisodeActionWriter $episodeActionWriter */
-		$episodeActionWriter = $this->container->get('OCA\GPodderSync\Db\EpisodeAction\EpisodeActionWriter');
-
 		$episodeActionEntity = new EpisodeActionEntity();
 		$episodeActionEntity->setPodcast("https://podcast_01.url");
 		$episodeActionEntity->setEpisode("https://episode_01.url");
@@ -48,10 +55,50 @@ class EpisodeActionGuidMigrationTest extends TestCase
 		$episodeActionEntity->setStarted(0);
 		$episodeActionEntity->setTotal(123);
 		$episodeActionEntity->setTimestamp("Mon Aug 23 01:58:56 GMT+02:00 2021");
-		$episodeActionEntity->setUserId("user0@127.0.0.1");
-		$episodeActionWriter->save($episodeActionEntity);
+		$episodeActionEntity->setUserId(self::USER_ID_0);
+		$this->episodeActionWriter->save($episodeActionEntity);
 
-		$episodeActionWriter->save($episodeActionEntity);
+		//and save again
+		$this->episodeActionWriter->save($episodeActionEntity);
+
+	}
+
+	public function testFindEpisodeActionByEpisodeUrlAndThenGuid()
+	{
+		$episodeActionEntity = new EpisodeActionEntity();
+		$episodeActionEntity->setPodcast("https://podcast_01.url");
+		$episodeActionEntity->setEpisode("https://episode_01.url");
+		$episodeActionEntity->setAction("PLAY");
+		$episodeActionEntity->setPosition(5);
+		$episodeActionEntity->setStarted(0);
+		$episodeActionEntity->setTotal(123);
+		$episodeActionEntity->setTimestamp("Mon Aug 23 01:58:56 GMT+02:00 2021");
+		$episodeActionEntity->setUserId(self::USER_ID_0);
+		$savedEpisodeActionEntity = $this->episodeActionWriter->save($episodeActionEntity);
+
+		/** @var EpisodeActionRepository $episodeActionRepository */
+		$episodeActionRepository = $this->container->get(EpisodeActionRepository::class);
+
+		self::assertSame(
+			$savedEpisodeActionEntity->getId(),
+			$episodeActionRepository->findByEpisodeIdentifier($episodeActionEntity->getEpisode(), self::USER_ID_0)->getId()
+		);
+
+		//update same episode action again this time with guid
+
+		$episodeActionEntityWithGuid = clone $episodeActionEntity;
+		$episodeActionEntityWithGuid->setGuid("guid:dadsaf4f4v");
+		$savedEpisodeActionEntityWithGuid = $this->episodeActionWriter->update($episodeActionEntityWithGuid);
+
+		self::assertSame(
+			$savedEpisodeActionEntityWithGuid->getId(),
+			$episodeActionRepository->findByEpisodeIdentifier($episodeActionEntityWithGuid->getEpisode(), self::USER_ID_0)->getId()
+		);
+
+		self::assertSame(
+			$savedEpisodeActionEntityWithGuid->getId(),
+			$episodeActionRepository->findByEpisodeIdentifier($episodeActionEntityWithGuid->getGuid(), self::USER_ID_0)->getId()
+		);
 
 	}
 

--- a/tests/Integration/EpisodeActionSaverGuidBackwardCompatbilityTest.php
+++ b/tests/Integration/EpisodeActionSaverGuidBackwardCompatbilityTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace tests\Integration;
+
+use OCA\GPodderSync\Core\EpisodeAction\EpisodeActionSaver;
+use OCP\AppFramework\App;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class EpisodeActionSaverGuidBackwardCompatbilityTest extends TestCase
+{
+
+	private const USER_ID_0 = "testuser0";
+
+	private \OCP\AppFramework\IAppContainer $container;
+
+	public function setUp(): void {
+		parent::setUp();
+		$app = new App('gpoddersync');
+		$this->container = $app->getContainer();
+	}
+
+	public function testUpdateWithoutGuidDoesNotNullGuid() : void
+	{
+		/** @var EpisodeActionSaver $episodeActionSaver */
+		$episodeActionSaver = $this->container->get(EpisodeActionSaver::class);
+
+		$episodeUrl = uniqid("test_https://dts.podtrac.com/redirect.mp3/chrt.fm/track");
+		$guid = uniqid("test_gid://art19-episode-locator/V0/Ktd");
+
+		$savedEpisodeActionEntity = $episodeActionSaver->saveEpisodeActions(
+			"[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='{$episodeUrl}', guid='{$guid}', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]",
+			self::USER_ID_0
+		)[0];
+
+		$savedEpisodeActionEntityWithoutGuidFromOldDevice = $episodeActionSaver->saveEpisodeActions(
+			"[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='{$episodeUrl}', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]",
+			self::USER_ID_0
+		)[0];
+
+		self::assertSame($savedEpisodeActionEntity->getId(), $savedEpisodeActionEntityWithoutGuidFromOldDevice->getId());
+		self::assertNotNull($savedEpisodeActionEntityWithoutGuidFromOldDevice->getGuid());
+	}
+}

--- a/tests/Integration/EpisodeActionSaverGuidMigrationTest.php
+++ b/tests/Integration/EpisodeActionSaverGuidMigrationTest.php
@@ -43,4 +43,25 @@ class EpisodeActionSaverGuidMigrationTest extends TestCase
 
 		self::assertSame($savedEpisodeActionEntityWithoutGuid->getId(), $savedEpisodeActionEntityWithGuid->getId());
 	}
+
+	public function testCreateEpisodeActionWithGuidThenCreateAgainWithGuidButDifferentEpisodeUrl() : void
+	{
+		/** @var EpisodeActionSaver $episodeActionSaver */
+		$episodeActionSaver = $this->container->get(EpisodeActionSaver::class);
+
+		$episodeUrl = uniqid("https://dts.podtrac.com/redirect.mp3/chrt.fm/track");
+		$guid = uniqid("gid://art19-episode-locator/V0/Ktd");
+
+		$savedEpisodeActionEntity = $episodeActionSaver->saveEpisodeActions(
+			"[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='{$episodeUrl}', guid='{$guid}', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]",
+			self::USER_ID_0
+		)[0];
+
+		$savedEpisodeActionEntityWithDifferentEpisodeUrl = $episodeActionSaver->saveEpisodeActions(
+			"[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='{$episodeUrl}_different', guid='{$guid}', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]",
+			self::USER_ID_0
+		)[0];
+
+		self::assertSame($savedEpisodeActionEntity->getId(), $savedEpisodeActionEntityWithDifferentEpisodeUrl->getId());
+	}
 }

--- a/tests/Integration/EpisodeActionSaverGuidMigrationTest.php
+++ b/tests/Integration/EpisodeActionSaverGuidMigrationTest.php
@@ -13,7 +13,7 @@ use Test\TestCase;
 class EpisodeActionSaverGuidMigrationTest extends TestCase
 {
 
-	private const USER_ID_0 = "user0@127.0.0.1";
+	private const USER_ID_0 = "testuser0";
 
 	private \OCP\AppFramework\IAppContainer $container;
 
@@ -28,8 +28,8 @@ class EpisodeActionSaverGuidMigrationTest extends TestCase
 		/** @var EpisodeActionSaver $episodeActionSaver */
 		$episodeActionSaver = $this->container->get(EpisodeActionSaver::class);
 
-		$episodeUrl = uniqid("https://dts.podtrac.com/redirect.mp3/chrt.fm/track");
-		$guid = uniqid("gid://art19-episode-locator/V0/Ktd");
+		$episodeUrl = uniqid("test_https://dts.podtrac.com/redirect.mp3/chrt.fm/track");
+		$guid = uniqid("test_gid://art19-episode-locator/V0/Ktd");
 
 		$savedEpisodeActionEntityWithoutGuid = $episodeActionSaver->saveEpisodeActions(
 			"[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='{$episodeUrl}', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]",
@@ -49,8 +49,8 @@ class EpisodeActionSaverGuidMigrationTest extends TestCase
 		/** @var EpisodeActionSaver $episodeActionSaver */
 		$episodeActionSaver = $this->container->get(EpisodeActionSaver::class);
 
-		$episodeUrl = uniqid("https://dts.podtrac.com/redirect.mp3/chrt.fm/track");
-		$guid = uniqid("gid://art19-episode-locator/V0/Ktd");
+		$episodeUrl = uniqid("test_https://dts.podtrac.com/redirect.mp3/chrt.fm/track");
+		$guid = uniqid("test_gid://art19-episode-locator/V0/Ktd");
 
 		$savedEpisodeActionEntity = $episodeActionSaver->saveEpisodeActions(
 			"[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='{$episodeUrl}', guid='{$guid}', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]",

--- a/tests/Integration/EpisodeActionSaverGuidMigrationTest.php
+++ b/tests/Integration/EpisodeActionSaverGuidMigrationTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace tests\Integration;
+
+use OCA\GPodderSync\Core\EpisodeAction\EpisodeActionSaver;
+use OCP\AppFramework\App;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class EpisodeActionSaverGuidMigrationTest extends TestCase
+{
+
+	private const USER_ID_0 = "user0@127.0.0.1";
+
+	private \OCP\AppFramework\IAppContainer $container;
+
+	public function setUp(): void {
+		parent::setUp();
+		$app = new App('gpoddersync');
+		$this->container = $app->getContainer();
+	}
+
+	public function testCreateEpisodeActionWithoutGuidThenCreateAgainWithGuid() : void
+	{
+		/** @var EpisodeActionSaver $episodeActionSaver */
+		$episodeActionSaver = $this->container->get(EpisodeActionSaver::class);
+
+		$episodeUrl = uniqid("https://dts.podtrac.com/redirect.mp3/chrt.fm/track");
+		$guid = uniqid("gid://art19-episode-locator/V0/Ktd");
+
+		$savedEpisodeActionEntityWithoutGuid = $episodeActionSaver->saveEpisodeActions(
+			"[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='{$episodeUrl}', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]",
+			self::USER_ID_0
+		)[0];
+
+		$savedEpisodeActionEntityWithGuid = $episodeActionSaver->saveEpisodeActions(
+			"[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='{$episodeUrl}', guid='{$guid}', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]",
+			self::USER_ID_0
+		)[0];
+
+		self::assertSame($savedEpisodeActionEntityWithoutGuid->getId(), $savedEpisodeActionEntityWithGuid->getId());
+	}
+}

--- a/tests/Unit/Core/EpisodeAction/EpisodeActionReaderTest.php
+++ b/tests/Unit/Core/EpisodeAction/EpisodeActionReaderTest.php
@@ -15,16 +15,30 @@ class EpisodeActionReaderTest extends TestCase {
 		$this->assertSame("https://chrt.fm/track/47G541/injector.simplecastaudio.com/f16c3da7-cf46-4a42-99b7-8467255c6086/episodes/e8e24c01-6157-40e8-9b5a-45d539aeb7e6/audio/128/default.mp3?aid=rss_feed&awCollectionId=f16c3da7-cf46-4a42-99b7-8467255c6086&awEpisodeId=e8e24c01-6157-40e8-9b5a-45d539aeb7e6&feed=wEl4UUJZ", $episodeAction->getEpisode());
 		$this->assertSame("PLAY", $episodeAction->getAction());
 		$this->assertSame("Tue May 18 23:45:11 GMT+02:00 2021", $episodeAction->getTimestamp());
+		$this->assertNull($episodeAction->getGuid());
 		$this->assertSame(31, $episodeAction->getStarted());
 		$this->assertSame(36, $episodeAction->getPosition());
 		$this->assertSame(2474, $episodeAction->getTotal());
+	}
 
+	public function testCreateFromStringWithGuid(): void {
+		$reader = new EpisodeActionReader();
+		$episodeActions = $reader->fromString("[EpisodeAction{podcast='https://rss.art19.com/dr-death-s3-miracle-man', episode='https://dts.podtrac.com/redirect.mp3/chrt.fm/track/9EE2G/pdst.fm/e/rss.art19.com/episodes/db0e3500', guid='gid://art19-episode-locator/V0/KtdfKfLndyWetCZ6t2WhUEFOFArDXRExVIb4Z1fh-TU', action=PLAY, timestamp=Mon Aug 23 01:58:56 GMT+02:00 2021, started=47, position=54, total=2252}]");
+		$episodeAction = $episodeActions[0];
+		$this->assertSame("https://rss.art19.com/dr-death-s3-miracle-man",  $episodeAction->getPodcast());
+		$this->assertSame("https://dts.podtrac.com/redirect.mp3/chrt.fm/track/9EE2G/pdst.fm/e/rss.art19.com/episodes/db0e3500", $episodeAction->getEpisode());
+		$this->assertSame("PLAY", $episodeAction->getAction());
+		$this->assertSame("Mon Aug 23 01:58:56 GMT+02:00 2021", $episodeAction->getTimestamp());
+		$this->assertSame("gid://art19-episode-locator/V0/KtdfKfLndyWetCZ6t2WhUEFOFArDXRExVIb4Z1fh-TU", $episodeAction->getGuid());
+		$this->assertSame(47, $episodeAction->getStarted());
+		$this->assertSame(54, $episodeAction->getPosition());
+		$this->assertSame(2252, $episodeAction->getTotal());
 	}
 
 	public function testCreateFromMultipleEpisodesString(): void {
 		$reader = new EpisodeActionReader();
 		$episodeActions = $reader->fromString('[EpisodeAction{podcast=\'https://example.com/feed.xml\', episode=\'https://example.com/episode1.mp3\', action=PLAY, timestamp=Tue May 18 23:45:11 GMT+02:00 2021, started=31, position=36, total=2474},EpisodeAction{podcast=\'https://example.com/feed.xml\', episode=\'https://example.com/episode2.mp3\', action=DOWNLOAD, timestamp=Tue May 18 23:46:42 GMT+02:00 2021, started=31, position=36, total=2474},EpisodeAction{podcast=\'https://example.org/feed.xml\', episode=\'https://chrt.fm/track/47G541/injector.simplecastaudio.com/f16c3da7-cf46-4a42-99b7-8467255c6086/episodes/e8e24c01-6157-40e8-9b5a-45d539aeb7e6/audio/128/default.mp3?aid=rss_feed&awCollectionId=f16c3da7-cf46-4a42-99b7-8467255c6086&awEpisodeId=e8e24c01-6157-40e8-9b5a-45d539aeb7e6&feed=wEl4UUJZ\', action=PLAY, timestamp=Tue May 18 23:45:14 GMT+02:00 2021, started=0, position=211, total=3121}]');
-		
+
 		$this->assertSame("https://example.com/feed.xml",  $episodeActions[0]->getPodcast());
 		$this->assertSame("https://example.com/episode1.mp3", $episodeActions[0]->getEpisode());
 		$this->assertSame("PLAY", $episodeActions[0]->getAction());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ if (!defined('PHPUNIT_RUN')) {
 }
 
 require_once __DIR__ . '/../../../lib/base.php';
-
+require_once __DIR__ . '/Helper/DatabaseTransaction.php';
 // Fix for "Autoload path not allowed: .../tests/lib/testcase.php"
 OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 


### PR DESCRIPTION
EpisodeActions get a new field named "guid" which serves as identifier. 
This PR adds the ability to deal with EpisodeActions with and without guid

AntennaPod currently does not provide the guid. Please use the following commit https://github.com/thrillfall/AntennaPod/commit/30e074f6db051367e1fcd91e0a979e6ea8609ede to make AntennaPod provid the guid