### PR TITLE
Use correct SQL syntax in repair step

### DIFF
--- a/lib/Migration/TimestampMigration.php
+++ b/lib/Migration/TimestampMigration.php
@@ -35,7 +35,7 @@ class TimestampMigration implements \OCP\Migration\IRepairStep
 		foreach ($timestamps as $timestamp) {
 			$timestampEpoch = (new DateTime($timestamp["timestamp"]))->format("U");
 			$sql = 'UPDATE `*PREFIX*gpodder_episode_action` '
-				. 'SET `timestamp_epoch` = ' . $timestampEpoch
+				. 'SET `timestamp_epoch` = ' . $timestampEpoch . ' '
 				. 'WHERE `timestamp_epoch` = 0';
 
 			$result = $this->db->executeUpdate($sql);


### PR DESCRIPTION
Fixes missing space in TimestampMigration.
Threw syntax errors on SQLite and MariaDB on `occ maintenance:repair`:

SQLite
```
...
- migrate timestamp values to integer to store unix epoch
     - ERROR: An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1 unrecognized token: "1633253235WHERE"
...
```
MariaDB
```
...
- migrate timestamp values to integer to store unix epoch
     - ERROR: An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '`timestamp_epoch` = 0' at line 1
...
```