### PR TITLE
Store epoch to correct entry, fix uninitialized variable

### DIFF
--- a/lib/Migration/TimestampMigration.php
+++ b/lib/Migration/TimestampMigration.php
@@ -32,7 +32,7 @@ class TimestampMigration implements \OCP\Migration\IRepairStep
 		$queryTimestamps = 'SELECT id, timestamp FROM `*PREFIX*gpodder_episode_action` WHERE timestamp_epoch = 0';
 		$timestamps = $this->db->executeQuery($queryTimestamps)->fetchAll();
 
-		$result = null;
+		$result = 0;
 
 		foreach ($timestamps as $timestamp) {
 			$timestampEpoch = (new DateTime($timestamp["timestamp"]))->format("U");
@@ -40,7 +40,7 @@ class TimestampMigration implements \OCP\Migration\IRepairStep
 				. 'SET `timestamp_epoch` = ' . $timestampEpoch . ' '
 				. 'WHERE `id` = ' . $timestamp["id"];
 
-			$result = $this->db->executeUpdate($sql);
+			$result += $this->db->executeUpdate($sql);
 
 		}
 


### PR DESCRIPTION
Found a bug in the migration: the UPDATE SQL query updates all entries where `timestamp_epoch` is 0. On my setup (sqlite) this lead to identical timestamp_epoch values in each updated entry. Selecting the entries by their id's fixes this.
 
Additionally, this fixes #39 by initializing `$result`.