### PR TITLE
Add timestamp to subscription change response

### DIFF
--- a/lib/Controller/SubscriptionChangeController.php
+++ b/lib/Controller/SubscriptionChangeController.php
@@ -42,10 +42,12 @@ class SubscriptionChangeController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
-	 * @return void
+	 * @return JSONResponse
 	 */
-	public function create($add, $remove) {
+	public function create($add, $remove): JSONResponse {
 		$this->subscriptionChangeSaver->saveSubscriptionChanges($add, $remove, $this->userId);
+
+		return new JSONResponse(["timestamp" => time()]);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #43.

Add timestamp in UTC Unix time seconds to subscription change response to be better compatible to gpodder.net api.
Identical to episode action POST response.