### PR TITLE
README changes: Add supported clients to readme, specify summary, add installation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # nextcloud-gpodder
 Nextcloud app that replicates basic gpodder.net api
 
-This app serves as synchronization endpoint for AntennaPod: https://github.com/AntennaPod/AntennaPod/pull/5243/  
-This feature will be available in AntennaPod as of version 2.5.0, which will be released towards the end of 2021.
+### Clients supporting sync
+| client | support status |
+| :- | :- |
+| [AntennaPod](https://antennapod.org) | Initial purpose for this project, as a synchronization endpoint for this client.<br> Support will be available [as of version 2.5.0](https://github.com/AntennaPod/AntennaPod/pull/5243/) (release probably towards end of 2021). |
+| [KDE Kasts](https://apps.kde.org/de/kasts/) | Supported since version 21.12 |
 
-# API
-## subscription
+### Installation
+Either from the official Nextcloud app store ([link to app page](https://apps.nextcloud.com/apps/gpoddersync)) or by downloading the [latest release](https://github.com/thrillfall/nextcloud-gpodder/releases/latest) and extracting it into your Nextcloud apps/ directory.
+
+## API
+### subscription
 * **get subscription changes**: `GET /index.php/apps/gpoddersync/subscriptions`
 	* *(optional)* GET parameter `since` (UNIX time)
 * **upload subscription changes** : `POST /index.php/apps/gpoddersync/subscription_change/create`
@@ -13,7 +19,7 @@ This feature will be available in AntennaPod as of version 2.5.0, which will be 
 
 The API replicates this: https://gpoddernet.readthedocs.io/en/latest/api/reference/subscriptions.html
 
-## episode action
+### episode action
 * **get episode actions**: `GET /index.php/apps/gpoddersync/episode_action`
 	* *(optional)* GET parameter `since` (UNIX time)
 	* fields: *podcast*, *episode*, *guid*, *action*, *timestamp*, *position*, *started*, *total*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nextcloud-gpodder
-Nextcloud app that replicates basic gpodder.net api
+Nextcloud app that replicates basic gpodder.net api to sync podcast consumer apps (podcatchers) like AntennaPod.
 
 ### Clients supporting sync
 | client | support status |


### PR DESCRIPTION
Closes #51 

List of supported clients is useful since there already are 2 of them (and hopefully more are to come).

Summary change to specify purpose of project.

Added link to Nextcloud app store page under Installation notice (to quickly find it, since the name is a bit different)

I hope this doesn't overload the readme.