### PR TITLE
Don't crash on unauthenticated api call + Add support for Nextcloud 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['sqlite']
-        server-versions: ['stable21', 'stable22', 'stable23']
+        server-versions: ['stable21', 'stable22', 'stable23', 'stable24']
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -78,7 +78,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['mysql']
-        server-versions: ['stable21', 'stable22', 'stable23']
+        server-versions: ['stable21', 'stable22', 'stable23', 'stable24']
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -145,7 +145,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['pgsql']
-        server-versions: ['stable21', 'stable22', 'stable23']
+        server-versions: ['stable21', 'stable22', 'stable23', 'stable24']
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -214,7 +214,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['oci']
-        server-versions: ['stable21', 'stable22', 'stable23']
+        server-versions: ['stable21', 'stable22', 'stable23', 'stable24']
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## 3.3.0 - 2022-05-03
+### Fixed
+- Don't crash on unauthenticated api call
+### Changed
 - Add support for Nextcloud 24
 
 ## 3.2.0 - 2021-12-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.0 - 2022-05-03
+- Add support for Nextcloud 24
+
 ## 3.2.0 - 2021-12-09
 ### Changed
 - Ignore subscriptions that have no url

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>GPodder Sync</name>
     <summary>replicate basic GPodder.net API</summary>
     <description><![CDATA[Expose GPodder API to sync podcast consumer apps like AntennaPod]]></description>
-    <version>3.2.0</version>
+    <version>3.3.0</version>
     <licence>agpl</licence>
     <author mail="thrillfall@disroot.org">Thrillfall</author>
     <namespace>GPodderSync</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
     </documentation>
     <dependencies>
         <php min-version="7.4"/>
-        <nextcloud min-version="20" max-version="23"/>
+        <nextcloud min-version="20" max-version="24"/>
     </dependencies>
     <repair-steps>
         <post-migration>

--- a/lib/Controller/EpisodeActionController.php
+++ b/lib/Controller/EpisodeActionController.php
@@ -26,7 +26,7 @@ class EpisodeActionController extends Controller {
 	) {
 		parent::__construct($AppName, $request);
 		$this->episodeActionRepository = $episodeActionRepository;
-		$this->userId = $UserId;
+		$this->userId = $UserId !== null ? $UserId : '';
 		$this->episodeActionSaver = $episodeActionSaver;
 		$this->request = $request;
 	}

--- a/lib/Controller/SubscriptionChangeController.php
+++ b/lib/Controller/SubscriptionChangeController.php
@@ -28,7 +28,7 @@ class SubscriptionChangeController extends Controller {
 		parent::__construct($AppName, $request);
 		$this->subscriptionChangeSaver = $subscriptionChangeSaver;
 		$this->subscriptionChangeRepository = $subscriptionChangeRepository;
-		$this->userId = $UserId;
+		$this->userId = $UserId !== null ? $UserId : '';
 	}
 
 	/**

--- a/tests/Integration/Controller/EpisodeActionControllerTest.php
+++ b/tests/Integration/Controller/EpisodeActionControllerTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace tests\Integration\Controller;
 
-use OC\AppFramework\Http\Request;
 use OC\Security\SecureRandom;
 use OCA\GPodderSync\Controller\EpisodeActionController;
 use OCA\GPodderSync\Core\EpisodeAction\EpisodeActionSaver;
@@ -14,6 +13,7 @@ use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionWriter;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use OCP\IConfig;
+use OCP\IRequest;
 use Test\TestCase;
 use tests\Helper\DatabaseTransaction;
 
@@ -49,7 +49,7 @@ class EpisodeActionControllerTest extends TestCase
 		$userId = uniqid("test_user");
 		$episodeActionController = new EpisodeActionController(
 			"gpoddersync",
-			new Request([], new SecureRandom(), self::getMockBuilder(IConfig::class)->getMock()),
+			$this->createMock(IRequest::class),
 			$userId,
 			$this->container->get(EpisodeActionRepository::class),
 			$this->container->get(EpisodeActionSaver::class)
@@ -102,8 +102,10 @@ class EpisodeActionControllerTest extends TestCase
    "total":  500
   }
 ]', true, 512, JSON_THROW_ON_ERROR);
-		$request = new Request([], new SecureRandom(), $this->getMockBuilder(IConfig::class)->getMock());
-		$request->setUrlParameters($payload);
+		$request = $this->createMock(IRequest::class);
+		$request->expects($this->once())
+				->method('getParams')
+				->will($this->returnValue($payload));
 		$episodeActionController = new EpisodeActionController(
 			"gpoddersync",
 			$request,

--- a/tests/Integration/Migration/TimestampMigrationTest.php
+++ b/tests/Integration/Migration/TimestampMigrationTest.php
@@ -5,7 +5,6 @@ namespace tests\Integration\Migration;
 
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use OC\AllConfig;
-use OC\Log;
 use OC\Migration\SimpleOutput;
 use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionEntity;
 use OCA\GPodderSync\Db\EpisodeAction\EpisodeActionMapper;
@@ -16,7 +15,6 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use test\TestCase;
 use tests\Helper\DatabaseTransaction;
-use tests\Helper\Writer\TestWriter;
 
 /**
  * @group DB
@@ -92,7 +90,7 @@ class TimestampMigrationTest extends TestCase
 		);
 
 		$timestampMigration = new TimestampMigration($this->dbConnection, $this->migrationConfig);
-		$timestampMigration->run(new SimpleOutput(new Log(new TestWriter()), "gpoddersync"));
+		$timestampMigration->run($this->createMock(SimpleOutput::class));
 
 		$scienceEpisodeActionAfterConversion = $this->episodeActionMapper->findByEpisodeIdentifier(
 			$scienceEpisodeActionEntity->getGuid(),


### PR DESCRIPTION
Fixes #63
Fixes #64 

I needed to change some things in a test because the signature of `OC\AppFramework\Http\Request` changed with v24.

Fixed the HTTP 500 error by catching the case that $UserId is null if not authorized since this threw the errors.

Keep in mind that I already changed the version to 3.3 and edited the changelog - so better check that I did no mistakes here.