### PR TITLE
Make since parameter optional, with 0 as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Either from the official Nextcloud app store ([link to app page](https://apps.ne
 * **get subscription changes**: `GET /index.php/apps/gpoddersync/subscriptions`
 	* *(optional)* GET parameter `since` (UNIX time)
 * **upload subscription changes** : `POST /index.php/apps/gpoddersync/subscription_change/create`
-	* returns nothing
+  * returns JSON with current timestamp
 
 The API replicates this: https://gpoddernet.readthedocs.io/en/latest/api/reference/subscriptions.html
 

--- a/lib/Controller/EpisodeActionController.php
+++ b/lib/Controller/EpisodeActionController.php
@@ -53,7 +53,7 @@ class EpisodeActionController extends Controller {
 	 * @param int $since
 	 * @return JSONResponse
 	 */
-	public function list(int $since): JSONResponse {
+	public function list(int $since = 0): JSONResponse {
 		$episodeActions = $this->episodeActionRepository->findAll($since, $this->userId);
 		$untypedEpisodeActionData = [];
 

--- a/lib/Controller/EpisodeActionController.php
+++ b/lib/Controller/EpisodeActionController.php
@@ -26,7 +26,7 @@ class EpisodeActionController extends Controller {
 	) {
 		parent::__construct($AppName, $request);
 		$this->episodeActionRepository = $episodeActionRepository;
-		$this->userId = $UserId !== null ? $UserId : '';
+		$this->userId = $UserId ?? '';
 		$this->episodeActionSaver = $episodeActionSaver;
 		$this->request = $request;
 	}

--- a/lib/Controller/SubscriptionChangeController.php
+++ b/lib/Controller/SubscriptionChangeController.php
@@ -54,23 +54,13 @@ class SubscriptionChangeController extends Controller {
 	 * @param int|null $since
 	 * @return JSONResponse
 	 */
-	public function list(int $since = null): JSONResponse {
-		$sinceDatetime = $this->createDateTimeFromTimestamp($since);
+	public function list(int $since = 0): JSONResponse {
+		$sinceDatetime = (new DateTime)->setTimestamp($since);
 		return new JSONResponse([
 			"add" => $this->extractUrlList($this->subscriptionChangeRepository->findAllSubscribed($sinceDatetime, $this->userId)),
 			"remove" => $this->extractUrlList($this->subscriptionChangeRepository->findAllUnSubscribed($sinceDatetime, $this->userId)),
 			"timestamp" => time()
 		]);
-	}
-
-	/**
-	 * @param int|null $since
-	 * @return DateTime
-	 */
-	private function createDateTimeFromTimestamp(?int $since): DateTime {
-		return ($since !== null)
-			? (new DateTime)->setTimestamp($since)
-			: (new DateTime('-1 week'));
 	}
 
 	/**

--- a/lib/Controller/SubscriptionChangeController.php
+++ b/lib/Controller/SubscriptionChangeController.php
@@ -28,7 +28,7 @@ class SubscriptionChangeController extends Controller {
 		parent::__construct($AppName, $request);
 		$this->subscriptionChangeSaver = $subscriptionChangeSaver;
 		$this->subscriptionChangeRepository = $subscriptionChangeRepository;
-		$this->userId = $UserId !== null ? $UserId : '';
+		$this->userId = $UserId ?? '';
 	}
 
 	/**

--- a/tests/Integration/Controller/EpisodeActionControllerTest.php
+++ b/tests/Integration/Controller/EpisodeActionControllerTest.php
@@ -87,6 +87,48 @@ class EpisodeActionControllerTest extends TestCase
 		self::assertSame("PLAY", $episodeActionInResponse['action']);
 	}
 
+	public function testEpisodeActionListWithoutSinceAction()
+	{
+		$userId = uniqid("test_user");
+		$episodeActionController = new EpisodeActionController(
+			"gpoddersync",
+			$this->createMock(IRequest::class),
+			$userId,
+			$this->container->get(EpisodeActionRepository::class),
+			$this->container->get(EpisodeActionSaver::class)
+		);
+
+		/** @var EpisodeActionWriter $episodeActionWriter */
+		$episodeActionWriter = $this->container->get(EpisodeActionWriter::class);
+
+		$episodeActionEntity = new EpisodeActionEntity();
+		$expectedPodcast = uniqid("test");
+		$episodeActionEntity->setPodcast($expectedPodcast);
+		$expectedEpisode = uniqid("test");
+		$episodeActionEntity->setEpisode($expectedEpisode);
+		$episodeActionEntity->setAction("PLAY");
+		$episodeActionEntity->setPosition(5);
+		$episodeActionEntity->setStarted(0);
+		$episodeActionEntity->setTotal(123);
+		$episodeActionEntity->setTimestampEpoch(1633520363);
+		$episodeActionEntity->setUserId($userId);
+		$episodeActionEntity->setGuid(self::TEST_GUID);
+		$episodeActionWriter->save($episodeActionEntity);
+
+		$response = $episodeActionController->list();
+		self::assertCount(1, $response->getData()['actions']);
+
+		$episodeActionInResponse = $response->getData()['actions'][0];
+		self::assertSame("2021-10-06T11:39:23", $episodeActionInResponse['timestamp']);
+		self::assertSame($expectedEpisode, $episodeActionInResponse['episode']);
+		self::assertSame($expectedPodcast, $episodeActionInResponse['podcast']);
+		self::assertSame(self::TEST_GUID, $episodeActionInResponse['guid']);
+		self::assertSame(5, $episodeActionInResponse['position']);
+		self::assertSame(0, $episodeActionInResponse['started']);
+		self::assertSame(123, $episodeActionInResponse['total']);
+		self::assertSame("PLAY", $episodeActionInResponse['action']);
+	}
+
 	public function testEpisodeActionCreateAction(): void {
 		$time = time();
 		$userId = uniqid('test_user', true);

--- a/tests/Integration/Controller/SubscriptionChangeControllerTest.php
+++ b/tests/Integration/Controller/SubscriptionChangeControllerTest.php
@@ -1,0 +1,180 @@
+<?php
+declare(strict_types=1);
+
+namespace tests\Integration\Controller;
+
+use OC\Security\SecureRandom;
+use OCA\GPodderSync\Controller\SubscriptionChangeController;
+use OCA\GPodderSync\Core\SubscriptionChange\SubscriptionChangeSaver;
+use OCA\GPodderSync\Db\SubscriptionChange\SubscriptionChangeRepository;
+use OCA\GPodderSync\Db\SubscriptionChange\SubscriptionChangeEntity;
+use OCA\GPodderSync\Db\SubscriptionChange\SubscriptionChangeWriter;
+use OCA\GPodderSync\Db\SubscriptionChange\SubscriptionChangeMapper;
+use OCP\AppFramework\App;
+use OCP\AppFramework\IAppContainer;
+use OCP\IConfig;
+use OCP\IRequest;
+use DateTime;
+use Test\TestCase;
+use tests\Helper\DatabaseTransaction;
+
+/**
+ * @group DB
+ */
+class SubscriptionChangeControllerTest extends TestCase
+{
+
+	use DatabaseTransaction;
+
+	const TEST_GUID = "test_guid_123q45345";
+	private IAppContainer $container;
+
+	public function setUp(): void {
+		parent::setUp();
+		$app = new App('gpoddersync');
+		$this->container = $app->getContainer();
+		$this->db = \OC::$server->getDatabaseConnection();
+	}
+
+	/**
+	 * @before
+	 */
+	public function before()
+	{
+		$this->startTransaction();
+	}
+
+    public function testSubscriptionChangeListAction()
+    {
+        $userId = uniqid("test_user");
+        $subscriptionChangeController = new SubscriptionChangeController(
+            "gpoddersync",
+            $this->createMock(IRequest::class),
+			$userId,
+            $this->container->get(SubscriptionChangeSaver::class),
+            $this->container->get(SubscriptionChangeRepository::class)
+        );
+
+		/** @var SubscriptionChangeWriter $subscriptionChangeWriter*/
+		$subscriptionChangeWriter = $this->container->get(SubscriptionChangeWriter::class);
+
+		$mark = 1633520363;
+		$subscriptionChangeEntity = new SubscriptionChangeEntity();
+		$expectedUrl1 = uniqid("test");
+		$subscriptionChangeEntity->setUrl($expectedUrl1);
+		$subscriptionChangeEntity->setSubscribed(true);
+		$subscriptionChangeEntity->setUpdated(date("Y-m-d\TH:i:s", $mark+600));
+		$subscriptionChangeEntity->setUserId($userId);
+
+		$subscriptionChangeWriter->create($subscriptionChangeEntity);
+
+		$subscriptionChangeEntity = new SubscriptionChangeEntity();
+		$expectedUrl2 = uniqid("test");
+		$subscriptionChangeEntity->setUrl($expectedUrl2);
+		$subscriptionChangeEntity->setSubscribed(false);
+		$subscriptionChangeEntity->setUpdated(date("Y-m-d\TH:i:s", $mark+1200));
+		$subscriptionChangeEntity->setUserId($userId);
+
+		$subscriptionChangeWriter->create($subscriptionChangeEntity);
+
+		$response = $subscriptionChangeController->list($mark);
+		self::assertCount(1, $response->getData()['add']);
+		self::assertCount(1, $response->getData()['remove']);
+
+		$subscriptionChangeInResponse1 = $response->getData()['add'][0];
+		$subscriptionChangeInResponse2 = $response->getData()['remove'][0];
+		self::assertSame($expectedUrl1, $subscriptionChangeInResponse1);
+		self::assertSame($expectedUrl2, $subscriptionChangeInResponse2);
+    }
+
+	public function testSubscriptionChangeListWithoutSinceAction()
+    {
+        $userId = uniqid("test_user");
+        $subscriptionChangeController = new SubscriptionChangeController(
+            "gpoddersync",
+            $this->createMock(IRequest::class),
+			$userId,
+            $this->container->get(SubscriptionChangeSaver::class),
+            $this->container->get(SubscriptionChangeRepository::class)
+        );
+
+		/** @var SubscriptionChangeWriter $subscriptionChangeWriter*/
+		$subscriptionChangeWriter = $this->container->get(SubscriptionChangeWriter::class);
+
+		$subscriptionChangeEntity = new SubscriptionChangeEntity();
+		$expectedUrl1 = uniqid("test");
+		$subscriptionChangeEntity->setUrl($expectedUrl1);
+		$subscriptionChangeEntity->setSubscribed(true);
+		$subscriptionChangeEntity->setUpdated("2021-10-06T11:39:23");
+		$subscriptionChangeEntity->setUserId($userId);
+
+		$subscriptionChangeWriter->create($subscriptionChangeEntity);
+
+		$subscriptionChangeEntity = new SubscriptionChangeEntity();
+		$expectedUrl2 = uniqid("test");
+		$subscriptionChangeEntity->setUrl($expectedUrl2);
+		$subscriptionChangeEntity->setSubscribed(false);
+		$subscriptionChangeEntity->setUpdated("2021-10-06T11:49:23");
+		$subscriptionChangeEntity->setUserId($userId);
+
+		$subscriptionChangeWriter->create($subscriptionChangeEntity);
+
+		$response = $subscriptionChangeController->list();
+		self::assertCount(1, $response->getData()['add']);
+		self::assertCount(1, $response->getData()['remove']);
+
+		$subscriptionChangeInResponse1 = $response->getData()['add'][0];
+		$subscriptionChangeInResponse2 = $response->getData()['remove'][0];
+		self::assertSame($expectedUrl1, $subscriptionChangeInResponse1);
+		self::assertSame($expectedUrl2, $subscriptionChangeInResponse2);
+    }
+
+	public function testSubscriptionChangeCreateAction(): void {
+		$time = time();
+		$userId = uniqid('test_user');
+
+		$subscriptionChangeController = new SubscriptionChangeController(
+            "gpoddersync",
+            $this->createMock(IRequest::class),
+			$userId,
+            $this->container->get(SubscriptionChangeSaver::class),
+            $this->container->get(SubscriptionChangeRepository::class)
+        );
+
+		$expectedAdd1 = "https://example.com/feed.rss";
+		$expectedAdd2 = "https://example.org/feed.xml";
+		$expectedRemove1 = "https://www.example.com/feed.rss";
+		$expectedRemove2 = "https://www.example.com/feed.xml";
+		
+		$response = $subscriptionChangeController->create(
+			[$expectedAdd1, $expectedAdd2],
+			[$expectedRemove1,$expectedRemove2]
+		);
+
+		$this->assertArrayHasKey('timestamp', $response->getData());
+		$this->assertGreaterThanOrEqual($time, $response->getData()['timestamp']);
+
+		/** @var SubscriptionChangeMapper $mapper */
+		$mapper = $this->container->query(SubscriptionChangeMapper::class);
+		$subscriptionChangeAddEntities = $mapper->findAllSubscriptionState(true, (new DateTime)->setTimestamp(0), $userId);
+		$subscriptionChangeRemoveEntities = $mapper->findAllSubscriptionState(false, (new DateTime)->setTimestamp(0), $userId);
+
+		$firstAdd = $subscriptionChangeAddEntities[0]->getUrl();
+		$secondAdd = $subscriptionChangeAddEntities[1]->getUrl();
+		$firstRemove = $subscriptionChangeRemoveEntities[0]->getUrl();
+		$secondRemove = $subscriptionChangeRemoveEntities[1]->getUrl();
+
+		$this->assertSame($expectedAdd1, $firstAdd);
+		$this->assertSame($expectedAdd2, $secondAdd);
+		$this->assertSame($expectedRemove1, $firstRemove);
+		$this->assertSame($expectedRemove2, $secondRemove);
+
+	}
+
+	/**
+	 * @after
+	 */
+	public function after(): void {
+		$this->rollbackTransaction();
+	}
+}


### PR DESCRIPTION
Fixes #72 

Makes since parameter optional (according to documentation) and changes the default value to 0 so that all episode_actions/subscriptions will be returned.

Small code simplification in null value check mentioned [here](https://github.com/thrillfall/nextcloud-gpodder/pull/65#pullrequestreview-962218962).

Correct the documentation regarding api responses.