### PR TITLE
Fix #99: Define return value of overriding jsonSerialize() 

### DIFF
--- a/lib/Db/SubscriptionChange/SubscriptionChangeEntity.php
+++ b/lib/Db/SubscriptionChange/SubscriptionChangeEntity.php
@@ -18,6 +18,9 @@ class SubscriptionChangeEntity extends Entity implements JsonSerializable {
 		$this->addType('subscribed','boolean');
 	}
 
+	/**
+	 * @return array<string,mixed>
+	 */
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,

--- a/lib/Db/SubscriptionChange/SubscriptionChangeEntity.php
+++ b/lib/Db/SubscriptionChange/SubscriptionChangeEntity.php
@@ -18,7 +18,7 @@ class SubscriptionChangeEntity extends Entity implements JsonSerializable {
 		$this->addType('subscribed','boolean');
 	}
 
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,
 			'url' => $this->url,


### PR DESCRIPTION
Fixes #99 

Since php8.0, return types of overriding functions need to be specified ([PHP doc: Return Type Compatibility with Internal Classes](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.type-compatibility-internal)).
Simply specifying return type as array solves the deprecation notice.