### PR TITLE
Hotfix release 3.7.1 - change to prefix key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.7.1 - 2022-11-11
+### Fixed
+- Fix error where app couldn't be installed with some databases
+
 ## 3.7.0 - 2022-11-10
 ### Fixed
 - Podcast overview page no longer produces errors when using php8.X

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>GPodder Sync</name>
     <summary>replicate basic GPodder.net API</summary>
     <description><![CDATA[Expose GPodder API to sync podcast consumer apps like AntennaPod]]></description>
-    <version>3.7.0</version>
+    <version>3.7.1</version>
     <licence>agpl</licence>
     <author mail="thrillfall@disroot.org">Thrillfall</author>
     <namespace>GPodderSync</namespace>

--- a/lib/Migration/Version0006Date20221106215500.php
+++ b/lib/Migration/Version0006Date20221106215500.php
@@ -14,6 +14,13 @@ class Version0006Date20221106215500 extends \OCP\Migration\SimpleMigrationStep {
                 $schema = $schemaClosure();
 
                 $table = $schema->getTable('gpodder_subscriptions');
+
+                // hotfix due to errors with too long key lengths (https://github.com/thrillfall/nextcloud-gpodder/issues/103)
+                $table->dropIndex('subscriptions_url_user');
+                $table->addUniqueIndex(['url', "user_id"], 'subscriptions_url_user', [ 
+                        'lengths' => [ 500, 200 ]
+                ]);
+
                 $table->changeColumn('url', ['length' => 1000]);
 
                 return $schema;

--- a/lib/Migration/Version0007Date202211111100.php
+++ b/lib/Migration/Version0007Date202211111100.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace OCA\GPodderSync\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+
+class Version0007Date202211111100 extends \OCP\Migration\SimpleMigrationStep {
+        public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+                /** @var ISchemaWrapper $schema */
+                $schema = $schemaClosure();
+
+                $table = $schema->getTable('gpodder_subscriptions');
+                $table->dropIndex('subscriptions_url_user');
+                $table->addUniqueIndex(['url', "user_id"], 'subscriptions_url_user', [ 
+                        'lengths' => [ 500, 200 ]
+                ]);
+
+                return $schema;
+        }
+}


### PR DESCRIPTION
Fixes #103 

Hotfix for 3.7.0 since this release lead to problems with some databases.
Utf8mb4 can take 4 byte per character, therefore `url` could grow to 4000 bytes. This isn't allowed on some systems since `url` is part of a key.
This hotfix changes the key to only use the first 500 characters of `url` as key. It's necessary to also alter the already existing migration due to migration execution order. The new migration is for systems that allowed larger keys and therefore already executed the now altered migration.
