### PR TITLE
Fix release number for 3.13.2 release

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>GPodder Sync</name>
     <summary>replicate basic GPodder.net API</summary>
     <description><![CDATA[Expose GPodder API to sync podcast consumer apps like AntennaPod]]></description>
-    <version>3.13.1</version>
+    <version>3.13.2</version>
     <licence>agpl</licence>
     <author mail="thrillfall@disroot.org">Thrillfall</author>
     <namespace>GPodderSync</namespace>


### PR DESCRIPTION
Hello

I didn't receive the 3.13.2 release because you forgot to update the info.xml file.
You'll have to remake the tag after merging this PR.

Thank you.